### PR TITLE
Fix/green flash

### DIFF
--- a/lightbar_driver/include/lightbar_driver/lightbar_driver_controller.h
+++ b/lightbar_driver/include/lightbar_driver/lightbar_driver_controller.h
@@ -27,7 +27,7 @@ namespace lightbar_driver
 {
 // Common LightBar IDs and their meaning
 enum LightBarID {FRONT_ID, BACK_ID};
-enum LightID {kGreenSolidOn = 0, kYellowDimOn = 2,kRightArrowOn = 3,kLeftArrowOn = 4,kYellowSidesOn = 5,kYellowFlashOn = 6};
+enum LightID {kGreenSolidOn = 0, kGreenFlashOn = 1, kYellowDimOn = 2,kRightArrowOn = 3,kLeftArrowOn = 4,kYellowSidesOn = 5,kYellowFlashOn = 6};
 enum LightState {OFF, ON};
 
 // Custom exceptions for lightbar connection
@@ -49,12 +49,13 @@ class LightBar
 public:
 	// Turn everything on by default
 	LightBar():LightBar (OFF,OFF,OFF,OFF,OFF,OFF){}              
-	explicit LightBar(int green_solid_on, int yellow_dim_on, 
+	explicit LightBar(int green_solid_on, int green_flash_on, int yellow_dim_on, 
 				int right_arrow_on, int left_arrow_on, 
 				int yellow_sides_on, int yellow_flash_on)
 				{
 					light_by_id = {
 						{kGreenSolidOn, green_solid_on},
+						{kGreenFlashOn, green_flash_on},
 						{kYellowDimOn, yellow_dim_on},
 						{kRightArrowOn, right_arrow_on},
 						{kLeftArrowOn, left_arrow_on},
@@ -85,11 +86,11 @@ public:
 	 * @brief LightBar () assignment operator
 	 * @param light_values all six values that need to be changed
 	 */
-	inline void operator()(int green_solid_on, int yellow_dim_on, 
+	inline void operator()(int green_solid_on, int green_flash_on, int yellow_dim_on, 
 				int right_arrow_on, int left_arrow_on, 
 				int yellow_sides_on, int yellow_flash_on)
 				{
-					LightBar rhs(green_solid_on, yellow_dim_on, right_arrow_on, 
+					LightBar rhs(green_solid_on, green_flash_on, yellow_dim_on, right_arrow_on, 
 						left_arrow_on, yellow_sides_on, yellow_flash_on);
 					this->light_by_id = rhs.light_by_id;
 				}

--- a/lightbar_driver/include/lightbar_driver/lightbar_driver_controller.h
+++ b/lightbar_driver/include/lightbar_driver/lightbar_driver_controller.h
@@ -48,7 +48,7 @@ class LightBar
 {
 public:
 	// Turn everything on by default
-	LightBar():LightBar (OFF,OFF,OFF,OFF,OFF,OFF){}              
+	LightBar():LightBar (OFF,OFF,OFF,OFF,OFF,OFF,OFF){}              
 	explicit LightBar(int green_solid_on, int green_flash_on, int yellow_dim_on, 
 				int right_arrow_on, int left_arrow_on, 
 				int yellow_sides_on, int yellow_flash_on)

--- a/lightbar_driver/src/lightbar_driver_application.cpp
+++ b/lightbar_driver/src/lightbar_driver_application.cpp
@@ -168,7 +168,7 @@ bool LightBarApplication::setLightsCB(cav_srvs::SetLightsRequest &req, cav_srvs:
     curr_front.light_by_id[kLeftArrowOn]  = req.set_state.left_arrow     == LightBarStatus::ON;
     curr_front.light_by_id[kRightArrowOn] = req.set_state.right_arrow    == LightBarStatus::ON;
     curr_front.light_by_id[kGreenSolidOn] = req.set_state.green_solid    == LightBarStatus::ON;
-    curr_front.light_by_id[kGreenFlashOn] =`req.set_state.green_flash    == LightBarStatus::ON;
+    curr_front.light_by_id[kGreenFlashOn] = req.set_state.green_flash    == LightBarStatus::ON;
     curr_front.light_by_id[kYellowFlashOn]= req.set_state.flash          == LightBarStatus::ON;
     curr_front.light_by_id[kYellowSidesOn]= req.set_state.sides_solid    == LightBarStatus::ON;
 

--- a/lightbar_driver/src/lightbar_driver_application.cpp
+++ b/lightbar_driver/src/lightbar_driver_application.cpp
@@ -125,6 +125,7 @@ bool LightBarApplication::getLightsCB(cav_srvs::GetLightsRequest&, cav_srvs::Get
     resp.status.left_arrow  = curr_front.light_by_id[kLeftArrowOn]       ? ON : OFF;
     resp.status.right_arrow = curr_front.light_by_id[kRightArrowOn]      ? ON : OFF;
     resp.status.green_solid = curr_front.light_by_id[kGreenSolidOn]      ? ON : OFF;
+    resp.status.green_flash = curr_front.light_by_id[kGreenFlashOn]      ? ON : OFF;
     resp.status.flash = curr_front.light_by_id[kYellowFlashOn]           ? ON : OFF;
     resp.status.sides_solid = curr_front.light_by_id[kYellowSidesOn]     ? ON : OFF;
 
@@ -167,6 +168,7 @@ bool LightBarApplication::setLightsCB(cav_srvs::SetLightsRequest &req, cav_srvs:
     curr_front.light_by_id[kLeftArrowOn]  = req.set_state.left_arrow     == LightBarStatus::ON;
     curr_front.light_by_id[kRightArrowOn] = req.set_state.right_arrow    == LightBarStatus::ON;
     curr_front.light_by_id[kGreenSolidOn] = req.set_state.green_solid    == LightBarStatus::ON;
+    curr_front.light_by_id[kGreenFlashOn] =`req.set_state.green_flash    == LightBarStatus::ON;
     curr_front.light_by_id[kYellowFlashOn]= req.set_state.flash          == LightBarStatus::ON;
     curr_front.light_by_id[kYellowSidesOn]= req.set_state.sides_solid    == LightBarStatus::ON;
 
@@ -219,7 +221,8 @@ void LightBarApplication::updateStatusTimerCB(const ros::WallTimerEvent &)
     light_bar_msg.yellow_solid  = curr_front.light_by_id[kYellowDimOn];         
     light_bar_msg.left_arrow    = curr_front.light_by_id[kLeftArrowOn];         
     light_bar_msg.right_arrow   = curr_front.light_by_id[kRightArrowOn];        
-    light_bar_msg.green_solid   = curr_front.light_by_id[kGreenSolidOn];        
+    light_bar_msg.green_solid   = curr_front.light_by_id[kGreenSolidOn]; 
+    light_bar_msg.green_flash   = curr_front.light_by_id[kGreenFlashOn];        
     light_bar_msg.flash         = curr_front.light_by_id[kYellowFlashOn];         
     light_bar_msg.sides_solid   = curr_front.light_by_id[kYellowSidesOn];   
 

--- a/lightbar_driver/src/lightbar_driver_controller.cpp
+++ b/lightbar_driver/src/lightbar_driver_controller.cpp
@@ -126,7 +126,7 @@ void LightBarController::updateStatus(const std::string& response)
 		{
 			int light_id = std::stoi(light.child("ID").child_value());\
 			// light IDs that are not used
-			if (light_id == 1 || light_id == 7 || light_id == 9 || light_id == 15)
+			if (light_id == 7 || light_id == 15)
 				continue;
 
 			// LightBar hardware http requests/responses assumes 1 as off state.

--- a/lightbar_driver/src/lightbar_driver_controller.cpp
+++ b/lightbar_driver/src/lightbar_driver_controller.cpp
@@ -259,7 +259,7 @@ void LightBarController::setState(const LightBarID& lbid, const LightID& lid, in
 
 void LightBarController::turnOffAll()
 {
-	LightBar off_state(OFF,OFF,OFF,OFF,OFF,OFF);
+	LightBar off_state(OFF,OFF,OFF,OFF,OFF,OFF,OFF);
 	LightBarController::setState(FRONT_ID, off_state);
 	LightBarController::setState(BACK_ID, off_state);
 	return;
@@ -267,7 +267,7 @@ void LightBarController::turnOffAll()
 
 void LightBarController::turnOnAll()
 {
-	LightBar on_state(ON,ON,ON,ON,ON,ON);
+	LightBar on_state(ON,ON,ON, ON,ON,ON,ON);
 	LightBarController::setState(FRONT_ID, on_state);
 	LightBarController::setState(BACK_ID, on_state);
 	return;

--- a/lightbar_driver/test/test_lightbar_driver_controller.cpp
+++ b/lightbar_driver/test/test_lightbar_driver_controller.cpp
@@ -24,7 +24,7 @@ namespace lightbar_driver
 TEST(LightParamTest, test)
 {
     // Initialize
-    LightBar on_bar(ON,ON,ON,ON,ON,ON);
+    LightBar on_bar(ON,ON,ON, ON,ON,ON,ON);
     LightBar off_bar;
     // testing ==
     ASSERT_FALSE(on_bar == off_bar);
@@ -60,7 +60,7 @@ TEST (GetStateTest, testException)
 TEST (SetStateTest, testException)
 {
     LightBarController lbc;
-    LightBar off_state, on_state(ON,ON,ON,ON,ON,ON);
+    LightBar off_state, on_state(ON,ON,ON, ON,ON,ON,ON);
     // Without hardware, should not be able to connect
     ASSERT_THROW(lbc.setState(FRONT_ID, on_state), CURL_EASY_PERFORM_ERROR);
     // There should not be any change in the local copy
@@ -91,7 +91,7 @@ TEST (UpdateStatusTest, test1)
     // test if updateStatus can update using XML string, and
     // test if it updates light IDs only are in the string
 	std::string response_str = "<ADAM-6256 status=\"OK\"><DO><ID>0</ID><VALUE>1</VALUE></DO><DO><ID>2</ID><VALUE>0</VALUE></DO><DO><ID>3</ID><VALUE>0</VALUE></DO></ADAM-6256> ";
-    LightBar response_front(OFF, ON, ON, OFF, OFF, OFF);
+    LightBar response_front(OFF, ON, ON, ON, OFF, OFF, OFF);
     LightBar response_back;
 	// Update according to string XML response
 	lbc.updateStatus(response_str);
@@ -102,8 +102,8 @@ TEST (UpdateStatusTest, test1)
 
     // test if updateStatus can update two lightbars at the same time
     response_str = "<ADAM-6256 status=\"OK\"><DO><ID>0</ID><VALUE>1</VALUE></DO><DO><ID>1</ID><VALUE>0</VALUE></DO><DO><ID>9</ID><VALUE>0</VALUE></DO><DO><ID>8</ID><VALUE>0</VALUE></DO></ADAM-6256> ";
-    response_front(OFF, ON, ON, OFF, OFF, OFF);
-    response_back(ON,OFF,OFF,OFF,OFF,OFF);
+    response_front(OFF, ON, ON, ON, OFF, OFF, OFF);
+    response_back(ON,OFF,OFF,OFF, OFF,OFF,OFF);
     lbc.updateStatus(response_str);
     front = lbc.getStateLocal(FRONT_ID);
     back = lbc.getStateLocal(BACK_ID);

--- a/lightbar_driver/test/test_lightbar_driver_controller.cpp
+++ b/lightbar_driver/test/test_lightbar_driver_controller.cpp
@@ -41,7 +41,7 @@ TEST(LightParamTest, test)
     // testing operator()
     on_bar.light_by_id[kGreenSolidOn] = OFF;
     ASSERT_FALSE(off_bar == on_bar);
-    off_bar(OFF,ON,ON,ON,ON,ON);
+    off_bar(OFF,ON, ON,ON,ON,ON,ON);
     ASSERT_TRUE(off_bar == on_bar);
 }
 
@@ -91,7 +91,7 @@ TEST (UpdateStatusTest, test1)
     // test if updateStatus can update using XML string, and
     // test if it updates light IDs only are in the string
 	std::string response_str = "<ADAM-6256 status=\"OK\"><DO><ID>0</ID><VALUE>1</VALUE></DO><DO><ID>2</ID><VALUE>0</VALUE></DO><DO><ID>3</ID><VALUE>0</VALUE></DO></ADAM-6256> ";
-    LightBar response_front(OFF, ON, ON, ON, OFF, OFF, OFF);
+    LightBar response_front(OFF, OFF, ON, ON, OFF, OFF, OFF);
     LightBar response_back;
 	// Update according to string XML response
 	lbc.updateStatus(response_str);
@@ -103,7 +103,7 @@ TEST (UpdateStatusTest, test1)
     // test if updateStatus can update two lightbars at the same time
     response_str = "<ADAM-6256 status=\"OK\"><DO><ID>0</ID><VALUE>1</VALUE></DO><DO><ID>1</ID><VALUE>0</VALUE></DO><DO><ID>9</ID><VALUE>0</VALUE></DO><DO><ID>8</ID><VALUE>0</VALUE></DO></ADAM-6256> ";
     response_front(OFF, ON, ON, ON, OFF, OFF, OFF);
-    response_back(ON,OFF,OFF,OFF, OFF,OFF,OFF);
+    response_back(ON,ON,OFF,OFF, OFF,OFF,OFF);
     lbc.updateStatus(response_str);
     front = lbc.getStateLocal(FRONT_ID);
     back = lbc.getStateLocal(BACK_ID);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Lightbar driver was not capable of controlling green flash pattern as it was added after the driver was written.

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/937
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Lightbar was not controlled automatically by CARMA. This PR fixes that.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration tested on Blue Lexus
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file | Not Needed
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.